### PR TITLE
Add support for updating dotnet tools

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -97,6 +97,7 @@ packageupdate --build
 3. **Solution Validation**: Checks for `Directory.Packages.props` (CPM requirement) and applies exclusion rules
 4. **Package Update** (`Updater.Update`): Updates package versions in `Directory.Packages.props`
 5. **Optional Build** (`DotnetStarter.Build`): Builds solution after update if `--build` flag is provided
+6. **Tool Manifest Update** (`ToolUpdater.Update`): Scans the target directory for `dotnet-tools.json` manifests and updates tool versions. This scan is independent of the solution scan, since `.config/dotnet-tools.json` usually sits at the repo root while the solution sits in a sub directory
 
 ### Key Components
 
@@ -108,6 +109,13 @@ packageupdate --build
   - Preserves file formatting (newlines, indentation, trailing newlines)
   - Only considers stable versions when current version is stable
   - Only considers pre-release versions when current version is pre-release
+
+- **ToolUpdater.cs**: Updates tool versions in a `dotnet-tools.json` manifest
+  - Reuses `Updater.GetLatestVersion`, so tools follow the same stable/pre-release rules as packages
+  - Respects `"pinned": true` on a tool entry, and the `--package` filter
+  - Malformed manifests are logged as a warning, not thrown
+
+- **ToolManifest.cs**: Parses a `dotnet-tools.json` manifest with `Utf8JsonReader`, capturing the byte range of each version value. Updates are spliced into the original bytes from the end of the file, so formatting is preserved exactly rather than being re-serialized
 
 - **PackageSourceReader.cs**: Reads NuGet sources from NuGet.config hierarchy using NuGet settings infrastructure
 
@@ -149,6 +157,34 @@ The tool only works with CPM. Each solution must have a `Directory.Packages.prop
 ### Package Pinning
 
 Packages with `Pinned="true"` attribute are never updated, even when explicitly targeted via `--package` flag.
+
+### Dotnet Tools
+
+Local dotnet tools are updated in every `dotnet-tools.json` manifest found under the target directory:
+
+```json
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "8.0.0",
+      "commands": [
+        "dotnet-ef"
+      ]
+    },
+    "packageupdate": {
+      "version": "4.0.0",
+      "commands": [
+        "packageupdate"
+      ],
+      "pinned": true
+    }
+  }
+}
+```
+
+Tools with `"pinned": true` are never updated. The dotnet CLI ignores the extra property, so `dotnet tool restore` and `dotnet tool list` continue to work.
 
 ### Package Migration
 
@@ -216,8 +252,10 @@ src/
 ├── PackageUpdate/          # Main tool project (dotnet global tool)
 │   ├── Program.cs          # Entry point and orchestration
 │   ├── Updater.cs          # Core update logic
+│   ├── ToolUpdater.cs      # dotnet-tools.json update logic
+│   ├── ToolManifest.cs     # dotnet-tools.json parsing and formatting preserving writes
 │   ├── CommandRunner.cs    # CLI parsing
-│   ├── FileSystem.cs       # Solution discovery
+│   ├── FileSystem.cs       # Solution and tool manifest discovery
 │   ├── PackageSourceReader.cs  # NuGet source config
 │   └── ...
 ├── Tests/                  # Unit tests

--- a/readme.md
+++ b/readme.md
@@ -102,11 +102,15 @@ packageupdate --build
 
 ### Behavior
 
- * Recursively scan the target directory for all directories containing a `.sln` file.
- * Perform a [dotnet restore](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-restore) on the directory.
- * Recursively scan the directory for `*.csproj` files.
- * Call [dotnet list package](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package) to get the list of pending packages.
- * Call [dotnet add package](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package) with the package and version.
+ * Recursively scan the target directory for `*.sln` and `*.slnx` files.
+ * Skip forked repositories, and any solution excluded via `PackageUpdateIgnores`.
+ * For each remaining solution, parse the `Directory.Packages.props` beside it. Solutions without one are skipped.
+ * Read the NuGet sources from the [nuget.config hierarchy](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied).
+ * For every `PackageVersion` that is not pinned, query those sources using the [NuGet client SDK](https://learn.microsoft.com/en-us/nuget/reference/nuget-client-sdk). A package whose current version is deprecated is migrated to its alternative. Every other package is moved to the highest listed version, where a stable version never moves to a pre-release.
+ * Write `Directory.Packages.props` back, preserving the original newlines, indentation and comments.
+ * In the `*.csproj` files under the solution, rename the `PackageReference` of any migrated package, and move every `VersionOverride` forward.
+ * Recursively scan the target directory for `dotnet-tools.json` manifests, and move every tool that is not pinned forward.
+ * Optionally build each solution after it has been updated.
 
 
 ## PackageUpdateIgnores
@@ -373,6 +377,84 @@ Overrides that point at a stable version work the same way, and are moved to new
 - `VersionOverride` entries are updated in all `*.csproj` files under each solution directory.
 - A `VersionOverride` is only skipped when the `PackageReference` itself has `Pinned="true"`. Pinning the central `PackageVersion` does not pin the override, so the deployed projects can stay fixed while a test project keeps floating.
 - The `--package` filter also applies to override updates.
+
+
+## Dotnet Tools
+
+
+### Overview
+
+[Local dotnet tools](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-local-tool) are declared in a `dotnet-tools.json` manifest. PackageUpdate updates the version of every tool in every manifest found under the target directory.
+
+Manifests are discovered independently of solutions, since `.config/dotnet-tools.json` usually sits at the root of a repository while the solution sits in a sub directory. Both `.config/dotnet-tools.json` and a `dotnet-tools.json` beside the solution are supported.
+
+
+### Example
+
+**Before:**
+
+```json
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "8.0.0",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}
+```
+
+**After running `packageupdate`:**
+
+```json
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.10",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}
+```
+
+Console output:
+
+```
+Updated tool dotnet-ef: 8.0.0 -> 10.0.10
+```
+
+
+### Pinning a Tool
+
+Add `"pinned": true` to prevent a tool from being updated:
+
+```json
+"dotnet-ef": {
+  "version": "8.0.0",
+  "commands": [
+    "dotnet-ef"
+  ],
+  "pinned": true
+}
+```
+
+The dotnet CLI ignores the extra property, so `dotnet tool restore` and `dotnet tool list` continue to work.
+
+
+### Behavior
+
+ * Version selection follows the same rule as central package versions: a stable version only moves to a newer stable, a pre-release also considers pre-releases.
+ * The `--package` filter also applies to tools, matched against the tool package id.
+ * Only the version value is rewritten. The rest of the manifest, including indentation, property order and trailing newline, is left byte for byte identical.
+ * A manifest that cannot be parsed is logged as a warning and left unchanged.
 
 
 ## Automatic Package Migration

--- a/readme.source.md
+++ b/readme.source.md
@@ -95,11 +95,15 @@ packageupdate --build
 
 ### Behavior
 
- * Recursively scan the target directory for all directories containing a `.sln` file.
- * Perform a [dotnet restore](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-restore) on the directory.
- * Recursively scan the directory for `*.csproj` files.
- * Call [dotnet list package](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package) to get the list of pending packages.
- * Call [dotnet add package](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package) with the package and version.
+ * Recursively scan the target directory for `*.sln` and `*.slnx` files.
+ * Skip forked repositories, and any solution excluded via `PackageUpdateIgnores`.
+ * For each remaining solution, parse the `Directory.Packages.props` beside it. Solutions without one are skipped.
+ * Read the NuGet sources from the [nuget.config hierarchy](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied).
+ * For every `PackageVersion` that is not pinned, query those sources using the [NuGet client SDK](https://learn.microsoft.com/en-us/nuget/reference/nuget-client-sdk). A package whose current version is deprecated is migrated to its alternative. Every other package is moved to the highest listed version, where a stable version never moves to a pre-release.
+ * Write `Directory.Packages.props` back, preserving the original newlines, indentation and comments.
+ * In the `*.csproj` files under the solution, rename the `PackageReference` of any migrated package, and move every `VersionOverride` forward.
+ * Recursively scan the target directory for `dotnet-tools.json` manifests, and move every tool that is not pinned forward.
+ * Optionally build each solution after it has been updated.
 
 
 ## PackageUpdateIgnores
@@ -348,6 +352,84 @@ Overrides that point at a stable version work the same way, and are moved to new
 - `VersionOverride` entries are updated in all `*.csproj` files under each solution directory.
 - A `VersionOverride` is only skipped when the `PackageReference` itself has `Pinned="true"`. Pinning the central `PackageVersion` does not pin the override, so the deployed projects can stay fixed while a test project keeps floating.
 - The `--package` filter also applies to override updates.
+
+
+## Dotnet Tools
+
+
+### Overview
+
+[Local dotnet tools](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-local-tool) are declared in a `dotnet-tools.json` manifest. PackageUpdate updates the version of every tool in every manifest found under the target directory.
+
+Manifests are discovered independently of solutions, since `.config/dotnet-tools.json` usually sits at the root of a repository while the solution sits in a sub directory. Both `.config/dotnet-tools.json` and a `dotnet-tools.json` beside the solution are supported.
+
+
+### Example
+
+**Before:**
+
+```json
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "8.0.0",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}
+```
+
+**After running `packageupdate`:**
+
+```json
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.10",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}
+```
+
+Console output:
+
+```
+Updated tool dotnet-ef: 8.0.0 -> 10.0.10
+```
+
+
+### Pinning a Tool
+
+Add `"pinned": true` to prevent a tool from being updated:
+
+```json
+"dotnet-ef": {
+  "version": "8.0.0",
+  "commands": [
+    "dotnet-ef"
+  ],
+  "pinned": true
+}
+```
+
+The dotnet CLI ignores the extra property, so `dotnet tool restore` and `dotnet tool list` continue to work.
+
+
+### Behavior
+
+ * Version selection follows the same rule as central package versions: a stable version only moves to a newer stable, a pre-release also considers pre-releases.
+ * The `--package` filter also applies to tools, matched against the tool package id.
+ * Only the version value is rewritten. The rest of the manifest, including indentation, property order and trailing newline, is left byte for byte identical.
+ * A manifest that cannot be parsed is logged as a warning and left unchanged.
 
 
 ## Automatic Package Migration

--- a/src/PackageUpdate/FileSystem.cs
+++ b/src/PackageUpdate/FileSystem.cs
@@ -13,6 +13,10 @@
         }
     }
 
+    // Covers both `.config/dotnet-tools.json` and the legacy `dotnet-tools.json` beside a solution
+    public static IEnumerable<string> FindToolManifests(string directory) =>
+        EnumerateFiles(directory, "dotnet-tools.json");
+
     static List<string> EnumerateFiles(string directory, string pattern)
     {
         var allFiles = new List<string>();

--- a/src/PackageUpdate/GlobalUsings.cs
+++ b/src/PackageUpdate/GlobalUsings.cs
@@ -1,5 +1,6 @@
 ﻿global using System.Collections.Concurrent;
 global using System.Diagnostics;
+global using System.Text.Json;
 global using System.Xml;
 global using System.Xml.Linq;
 global using CommandLine;

--- a/src/PackageUpdate/Program.cs
+++ b/src/PackageUpdate/Program.cs
@@ -31,6 +31,19 @@ static async Task Inner(string directory, string? package, bool build)
         await TryProcessSolution(cache, solution, package, build);
     }
 
+    // Tool manifests are scanned independently of solutions, since `.config/dotnet-tools.json`
+    // usually sits at the repository root while the solution sits in a sub directory
+    foreach (var manifest in FileSystem.FindToolManifests(directory))
+    {
+        if (ForkDetector.ShouldSkip(directory, manifest))
+        {
+            Log.Information("  Skipping fork: {Manifest}", manifest);
+            continue;
+        }
+
+        await TryProcessToolManifest(cache, manifest, package);
+    }
+
     if (build)
     {
         await DotnetStarter.Shutdown();
@@ -55,6 +68,39 @@ static async Task TryProcessSolution(SourceCacheContext cache, string solution, 
             solution,
             e.Message);
     }
+}
+
+static async Task TryProcessToolManifest(SourceCacheContext cache, string manifest, string? package)
+{
+    try
+    {
+        await ProcessToolManifest(cache, manifest, package);
+    }
+    catch (Exception e)
+    {
+        Log.Error(
+            """
+            Failed to process tool manifest: {Manifest}.
+            Error: {Message}
+            """,
+            manifest,
+            e.Message);
+    }
+}
+
+static async Task ProcessToolManifest(SourceCacheContext cache, string manifest, string? package)
+{
+    if (Excluder.ShouldExclude(manifest))
+    {
+        Log.Information("  Exclude: {Manifest}", manifest);
+        return;
+    }
+
+    Log.Information("  {Manifest}", manifest);
+
+    var stopwatch = Stopwatch.StartNew();
+    await ToolUpdater.Update(cache, manifest, package);
+    Log.Information("    Updated in {Elapsed}", Formatter.FormatElapsed(stopwatch.Elapsed));
 }
 
 static async Task ProcessSolution(SourceCacheContext cache, string solution, string? package, bool build)

--- a/src/PackageUpdate/ToolEntry.cs
+++ b/src/PackageUpdate/ToolEntry.cs
@@ -1,0 +1,11 @@
+/// <summary>
+/// A tool declared in a `dotnet-tools.json` manifest.
+/// <see cref="VersionStart" /> and <see cref="VersionLength" /> locate the version value in the
+/// manifest bytes, so it can be replaced without reformatting the rest of the file.
+/// </summary>
+record ToolEntry(
+    string Package,
+    string Version,
+    int VersionStart,
+    int VersionLength,
+    bool Pinned);

--- a/src/PackageUpdate/ToolManifest.cs
+++ b/src/PackageUpdate/ToolManifest.cs
@@ -1,0 +1,91 @@
+static class ToolManifest
+{
+    static byte[] bom = [0xEF, 0xBB, 0xBF];
+
+    static JsonReaderOptions options = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    public static List<ToolEntry> Read(byte[] bytes)
+    {
+        // Utf8JsonReader does not skip a byte order mark
+        var offset = bytes.AsSpan().StartsWith(bom) ? bom.Length : 0;
+        var reader = new Utf8JsonReader(bytes.AsSpan(offset), options);
+
+        var entries = new List<ToolEntry>();
+        var inTools = false;
+        string? tool = null;
+        string? property = null;
+        string? version = null;
+        var versionStart = 0;
+        var versionLength = 0;
+        var pinned = false;
+
+        while (reader.Read())
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.PropertyName:
+                    var name = reader.GetString()!;
+                    switch (reader.CurrentDepth)
+                    {
+                        case 1:
+                            inTools = name == "tools";
+                            break;
+                        case 2 when inTools:
+                            tool = name;
+                            version = null;
+                            pinned = false;
+                            break;
+                        case 3 when inTools:
+                            property = name;
+                            break;
+                    }
+
+                    break;
+
+                case JsonTokenType.String
+                    when inTools && reader.CurrentDepth == 3 && property == "version":
+                    version = reader.GetString();
+                    // TokenStartIndex is the opening quote, so step over it to get the raw value
+                    versionStart = offset + (int) reader.TokenStartIndex + 1;
+                    versionLength = reader.ValueSpan.Length;
+                    break;
+
+                case JsonTokenType.True
+                    when inTools && reader.CurrentDepth == 3 && property == "pinned":
+                    pinned = true;
+                    break;
+
+                // End of a single tool
+                case JsonTokenType.EndObject when inTools && reader.CurrentDepth == 2:
+                    if (tool != null &&
+                        version != null)
+                    {
+                        entries.Add(new(tool, version, versionStart, versionLength, pinned));
+                    }
+
+                    tool = null;
+                    break;
+            }
+        }
+
+        return entries;
+    }
+
+    public static byte[] ApplyUpdates(byte[] bytes, List<(ToolEntry Tool, NuGetVersion Version)> updates)
+    {
+        var result = new List<byte>(bytes);
+
+        // Splice from the end of the file so the offsets of earlier tools stay valid
+        foreach (var (tool, version) in updates.OrderByDescending(_ => _.Tool.VersionStart))
+        {
+            result.RemoveRange(tool.VersionStart, tool.VersionLength);
+            result.InsertRange(tool.VersionStart, Encoding.UTF8.GetBytes(version.ToString()));
+        }
+
+        return [..result];
+    }
+}

--- a/src/PackageUpdate/ToolUpdater.cs
+++ b/src/PackageUpdate/ToolUpdater.cs
@@ -1,0 +1,82 @@
+public static class ToolUpdater
+{
+    public static async Task Update(
+        SourceCacheContext cache,
+        string manifestPath,
+        string? packageName)
+    {
+        var bytes = await File.ReadAllBytesAsync(manifestPath);
+
+        List<ToolEntry> tools;
+        try
+        {
+            tools = ToolManifest.Read(bytes);
+        }
+        catch (JsonException exception)
+        {
+            Log.Warning(
+                "Failed to parse tool manifest {FilePath}. Error: {Message}",
+                manifestPath,
+                exception.Message);
+            return;
+        }
+
+        var candidates = tools
+            .Where(_ => !_.Pinned)
+            .ToList();
+
+        // Filter to specific package if requested
+        if (!string.IsNullOrEmpty(packageName))
+        {
+            candidates = candidates
+                .Where(_ => string.Equals(_.Package, packageName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(manifestPath)!;
+        var sources = PackageSourceReader.Read(directory);
+
+        var updates = new List<(ToolEntry Tool, NuGetVersion Version)>();
+
+        foreach (var tool in candidates)
+        {
+            if (!NuGetVersion.TryParse(tool.Version, out var currentVersion))
+            {
+                continue;
+            }
+
+            var latestMetadata = await Updater.GetLatestVersion(
+                tool.Package,
+                currentVersion,
+                sources,
+                cache);
+
+            if (latestMetadata == null)
+            {
+                continue;
+            }
+
+            var latestVersion = latestMetadata.Identity.Version;
+
+            if (latestVersion <= currentVersion)
+            {
+                continue;
+            }
+
+            updates.Add((tool, latestVersion));
+            Log.Information("Updated tool {Package}: {NuGetVersion} -> {LatestVersion}", tool.Package, currentVersion, latestVersion);
+        }
+
+        if (updates.Count == 0)
+        {
+            return;
+        }
+
+        await File.WriteAllBytesAsync(manifestPath, ToolManifest.ApplyUpdates(bytes, updates));
+    }
+}

--- a/src/PackageUpdate/nuget.md
+++ b/src/PackageUpdate/nuget.md
@@ -35,6 +35,7 @@ If no directory is passed the current directory will be used.
  * Updates all packages across all solutions in a directory
  * Respects `Pinned="true"` attribute to skip specific packages
  * Updates `VersionOverride` entries in projects independently of the central version
+ * Updates local dotnet tools in `dotnet-tools.json` manifests
  * Automatically migrates deprecated packages to recommended alternatives
  * Preserves file formatting (newlines, indentation)
  * Queries all configured NuGet sources
@@ -47,6 +48,18 @@ Add `Pinned="true"` to prevent a package from being updated:
 
 ```xml
 <PackageVersion Include="System.ValueTuple" Version="4.5.0" Pinned="true" />
+```
+
+Add `"pinned": true` to prevent a dotnet tool from being updated:
+
+```json
+"dotnet-ef": {
+  "version": "8.0.0",
+  "commands": [
+    "dotnet-ef"
+  ],
+  "pinned": true
+}
 ```
 
 

--- a/src/Tests/GlobalUsings.cs
+++ b/src/Tests/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using System.Xml.Linq;
+﻿global using System.Text.Json;
+global using System.Xml.Linq;
 global using NuGet.Configuration;
 global using NuGet.Protocol.Core.Types;
 global using NuGet.Versioning;

--- a/src/Tests/ToolManifestTests.cs
+++ b/src/Tests/ToolManifestTests.cs
@@ -1,0 +1,175 @@
+public class ToolManifestTests
+{
+    static string manifest =
+        """
+        {
+          "version": 1,
+          "isRoot": true,
+          "tools": {
+            "dotnet-ef": {
+              "version": "5.0.0",
+              "commands": [
+                "dotnet-ef"
+              ],
+              "rollForward": false
+            },
+            "packageupdate": {
+              "version": "4.0.0",
+              "commands": [
+                "packageupdate"
+              ],
+              "pinned": true
+            }
+          }
+        }
+        """;
+
+    [Test]
+    public async Task ReadsTools()
+    {
+        var entries = ToolManifest.Read(Encoding.UTF8.GetBytes(manifest));
+
+        await Assert.That(entries).Count().IsEqualTo(2);
+
+        await Assert.That(entries[0].Package).IsEqualTo("dotnet-ef");
+        await Assert.That(entries[0].Version).IsEqualTo("5.0.0");
+        await Assert.That(entries[0].Pinned).IsFalse();
+
+        await Assert.That(entries[1].Package).IsEqualTo("packageupdate");
+        await Assert.That(entries[1].Version).IsEqualTo("4.0.0");
+        await Assert.That(entries[1].Pinned).IsTrue();
+    }
+
+    [Test]
+    public async Task VersionOffsetsPointAtTheVersionValue()
+    {
+        var bytes = Encoding.UTF8.GetBytes(manifest);
+
+        foreach (var entry in ToolManifest.Read(bytes))
+        {
+            var value = Encoding.UTF8.GetString(bytes, entry.VersionStart, entry.VersionLength);
+            await Assert.That(value).IsEqualTo(entry.Version);
+        }
+    }
+
+    [Test]
+    public async Task ApplyUpdatesOnlyReplacesVersions()
+    {
+        var bytes = Encoding.UTF8.GetBytes(manifest);
+        var entries = ToolManifest.Read(bytes);
+
+        // The first replacement is longer than the value it replaces, so the offsets of the
+        // second tool would be stale if the splices were not applied from the end of the file
+        var updated = ToolManifest.ApplyUpdates(
+            bytes,
+            [
+                (entries[0], NuGetVersion.Parse("9.0.1-preview.1")),
+                (entries[1], NuGetVersion.Parse("4.3.0"))
+            ]);
+
+        var result = Encoding.UTF8.GetString(updated);
+
+        await Assert.That(result)
+            .IsEqualTo(
+                manifest
+                    .Replace("\"5.0.0\"", "\"9.0.1-preview.1\"")
+                    .Replace("\"4.0.0\"", "\"4.3.0\""));
+    }
+
+    [Test]
+    public async Task HandlesByteOrderMark()
+    {
+        byte[] bytes = [..Encoding.UTF8.GetPreamble(), ..Encoding.UTF8.GetBytes(manifest)];
+
+        var entries = ToolManifest.Read(bytes);
+
+        await Assert.That(entries).Count().IsEqualTo(2);
+
+        var value = Encoding.UTF8.GetString(bytes, entries[0].VersionStart, entries[0].VersionLength);
+        await Assert.That(value).IsEqualTo("5.0.0");
+
+        var updated = ToolManifest.ApplyUpdates(bytes, [(entries[0], NuGetVersion.Parse("9.0.1"))]);
+
+        // The byte order mark must survive
+        await Assert.That(updated.AsSpan().StartsWith(Encoding.UTF8.GetPreamble())).IsTrue();
+        await Assert.That(Encoding.UTF8.GetString(updated))
+            .IsEqualTo("﻿" + manifest.Replace("\"5.0.0\"", "\"9.0.1\""));
+    }
+
+    [Test]
+    public async Task NoToolsSection()
+    {
+        var content =
+            """
+            {
+              "version": 1,
+              "isRoot": true
+            }
+            """;
+
+        var entries = ToolManifest.Read(Encoding.UTF8.GetBytes(content));
+
+        await Assert.That(entries).IsEmpty();
+    }
+
+    [Test]
+    public async Task ToolWithoutVersionIsIgnored()
+    {
+        var content =
+            """
+            {
+              "version": 1,
+              "tools": {
+                "dotnet-ef": {
+                  "commands": [
+                    "dotnet-ef"
+                  ]
+                },
+                "packageupdate": {
+                  "version": "4.0.0"
+                }
+              }
+            }
+            """;
+
+        var entries = ToolManifest.Read(Encoding.UTF8.GetBytes(content));
+
+        await Assert.That(entries).Count().IsEqualTo(1);
+        await Assert.That(entries[0].Package).IsEqualTo("packageupdate");
+    }
+
+    [Test]
+    public async Task CommandsAreNotTreatedAsVersions()
+    {
+        var content =
+            """
+            {
+              "tools": {
+                "dotnet-ef": {
+                  "commands": [
+                    "version"
+                  ],
+                  "version": "5.0.0"
+                }
+              }
+            }
+            """;
+
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var entries = ToolManifest.Read(bytes);
+
+        await Assert.That(entries).Count().IsEqualTo(1);
+        await Assert.That(entries[0].Version).IsEqualTo("5.0.0");
+
+        var value = Encoding.UTF8.GetString(bytes, entries[0].VersionStart, entries[0].VersionLength);
+        await Assert.That(value).IsEqualTo("5.0.0");
+    }
+
+    [Test]
+    public async Task MalformedManifestThrows()
+    {
+        var read = () => ToolManifest.Read("not json"u8.ToArray());
+
+        await Assert.That(read).Throws<JsonException>();
+    }
+}

--- a/src/Tests/ToolUpdaterTests.cs
+++ b/src/Tests/ToolUpdaterTests.cs
@@ -1,0 +1,239 @@
+public class ToolUpdaterTests
+{
+    static string nugetConfig =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+          <packageSources>
+            <clear />
+            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+          </packageSources>
+        </configuration>
+        """;
+
+    static async Task<string> RunScenario(string manifest, string? package = null)
+    {
+        using var cache = new SourceCacheContext
+        {
+            RefreshMemoryCache = true
+        };
+
+        using var directory = new TempDirectory();
+        var config = Path.Combine(directory, ".config");
+        Directory.CreateDirectory(config);
+
+        await File.WriteAllTextAsync(Path.Combine(directory, "nuget.config"), nugetConfig);
+
+        var manifestPath = Path.Combine(config, "dotnet-tools.json");
+        await File.WriteAllTextAsync(manifestPath, manifest);
+
+        await ToolUpdater.Update(cache, manifestPath, package);
+
+        return await File.ReadAllTextAsync(manifestPath);
+    }
+
+    static string? VersionOf(string manifest, string tool) =>
+        JsonDocument.Parse(manifest)
+            .RootElement
+            .GetProperty("tools")
+            .GetProperty(tool)
+            .GetProperty("version")
+            .GetString();
+
+    [Test]
+    public async Task UpdatesToolVersion()
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "isRoot": true,
+              "tools": {
+                "dotnet-ef": {
+                  "version": "5.0.0",
+                  "commands": [
+                    "dotnet-ef"
+                  ]
+                }
+              }
+            }
+            """;
+
+        var result = await RunScenario(manifest);
+
+        var version = VersionOf(result, "dotnet-ef");
+        await Assert.That(NuGetVersion.TryParse(version, out var updated)).IsTrue();
+        await Assert.That(updated! > NuGetVersion.Parse("5.0.0")).IsTrue();
+
+        // A stable version must never move to a pre-release
+        await Assert.That(updated!.IsPrerelease).IsFalse();
+    }
+
+    [Test]
+    public async Task PreservesEverythingExceptTheVersion()
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "isRoot": true,
+              "tools": {
+                "dotnet-ef": {
+                  "version": "5.0.0",
+                  "commands": [
+                    "dotnet-ef"
+                  ],
+                  "rollForward": false
+                }
+              }
+            }
+            """;
+
+        var result = await RunScenario(manifest);
+
+        var version = VersionOf(result, "dotnet-ef");
+        await Assert.That(version).IsNotEqualTo("5.0.0");
+
+        // Byte for byte identical apart from the single version value
+        await Assert.That(result).IsEqualTo(manifest.Replace("\"5.0.0\"", $"\"{version}\""));
+    }
+
+    [Test]
+    public async Task PreservesNonStandardFormatting()
+    {
+        // Tab indented, no trailing newline
+        var manifest = "{\n\t\"version\": 1,\n\t\"tools\": {\n\t\t\"dotnet-ef\": {\"version\":\"5.0.0\"}\n\t}\n}";
+
+        var result = await RunScenario(manifest);
+
+        var version = VersionOf(result, "dotnet-ef");
+        await Assert.That(version).IsNotEqualTo("5.0.0");
+        await Assert.That(result).IsEqualTo(manifest.Replace("\"5.0.0\"", $"\"{version}\""));
+    }
+
+    [Test]
+    public async Task RespectsPinnedTool()
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "isRoot": true,
+              "tools": {
+                "dotnet-ef": {
+                  "version": "5.0.0",
+                  "commands": [
+                    "dotnet-ef"
+                  ],
+                  "pinned": true
+                },
+                "packageupdate": {
+                  "version": "4.0.0",
+                  "commands": [
+                    "packageupdate"
+                  ]
+                }
+              }
+            }
+            """;
+
+        var result = await RunScenario(manifest);
+
+        await Assert.That(VersionOf(result, "dotnet-ef")).IsEqualTo("5.0.0");
+        await Assert.That(VersionOf(result, "packageupdate")).IsNotEqualTo("4.0.0");
+    }
+
+    [Test]
+    public async Task RespectsPackageFilter()
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "tools": {
+                "dotnet-ef": {
+                  "version": "5.0.0"
+                },
+                "packageupdate": {
+                  "version": "4.0.0"
+                }
+              }
+            }
+            """;
+
+        var result = await RunScenario(manifest, "packageupdate");
+
+        await Assert.That(VersionOf(result, "dotnet-ef")).IsEqualTo("5.0.0");
+        await Assert.That(VersionOf(result, "packageupdate")).IsNotEqualTo("4.0.0");
+    }
+
+    [Test]
+    public async Task PackageFilterIsCaseInsensitive()
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "tools": {
+                "packageupdate": {
+                  "version": "4.0.0"
+                }
+              }
+            }
+            """;
+
+        var result = await RunScenario(manifest, "PackageUpdate");
+
+        await Assert.That(VersionOf(result, "packageupdate")).IsNotEqualTo("4.0.0");
+    }
+
+    [Test]
+    public async Task SkipsInvalidVersion()
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "tools": {
+                "dotnet-ef": {
+                  "version": "not-a-version"
+                }
+              }
+            }
+            """;
+
+        var result = await RunScenario(manifest);
+
+        await Assert.That(result).IsEqualTo(manifest);
+    }
+
+    [Test]
+    public async Task SkipsUnknownTool()
+    {
+        var manifest =
+            """
+            {
+              "version": 1,
+              "tools": {
+                "ThisToolDefinitelyDoesNotExist12345": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+            """;
+
+        var result = await RunScenario(manifest);
+
+        await Assert.That(result).IsEqualTo(manifest);
+    }
+
+    [Test]
+    public async Task MalformedManifestIsLeftUnchanged()
+    {
+        var manifest = "{ not json";
+
+        var result = await RunScenario(manifest);
+
+        await Assert.That(result).IsEqualTo(manifest);
+    }
+}


### PR DESCRIPTION
Scan the target directory for dotnet-tools.json manifests and move each tool version forward, reusing the source config, version selection and caching already used for package updates.

Manifests are discovered independently of solutions, since .config/dotnet-tools.json usually sits at the repo root while the solution sits in a sub directory. Fork skipping and PackageUpdateIgnores still apply.

Only the version value is rewritten, so manifest formatting is preserved exactly. Tools with "pinned": true are skipped, mirroring Pinned="true" on a PackageVersion.

Also refresh the stale Behavior list in the readme, which still described the old dotnet restore / list package / add package implementation.